### PR TITLE
fix: fix pip deps

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,14 +6,17 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: docs
     steps:
       - uses: actions/checkout@v4
 
@@ -21,15 +24,29 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
       - name: Install deps
+        working-directory: docs
         run: pip install -r requirements.txt
 
       - name: Build site
+        working-directory: docs
         run: mkdocs build --strict
 
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/site
-          cname: cadman.kitechsoftware.com
+          path: docs/site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+ 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -27,7 +27,8 @@ markdown_extensions:
   - pymdownx.highlight
   - pymdownx.superfences
   - pymdownx.details
-  - pymdownx.tabs
+  - pymdownx.tabbed:
+      alternate_style: true
 
 plugins:
   - search

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs>=1.6
 mkdocs-material>=9.5,<10
+pymdown-extensions>=10.0


### PR DESCRIPTION
This pull request updates the documentation build and deployment workflow to use GitHub Pages' official actions, and makes some improvements to the documentation configuration. The most significant changes involve switching from a third-party deployment action to the official GitHub Pages workflow, updating permissions, and enhancing the documentation's tabbed interface.

**GitHub Actions workflow updates:**

* Switched the deployment process in `.github/workflows/docs.yml` from `peaceiris/actions-gh-pages` to the official GitHub Pages actions (`actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages`), updated permissions, and added a concurrency group for deployments.

**Documentation configuration improvements:**

* Changed the `pymdownx.tabs` extension to `pymdownx.tabbed` in `docs/mkdocs.yml` and enabled `alternate_style` for improved tabbed content appearance.
* Added `pymdown-extensions>=10.0` to `docs/requirements.txt` to support the new tabbed extension.