### PR TITLE
👷 ci(build): add work_dir to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ permissions:
 on:
   workflow_call:
     inputs:
+      work_dir:
+        description: 'Working directory for cargo commands'
+        default: '.'
+        type: string
       binary_tag:
         description: 'Base name for output binaries and packages'
         default: 'cadman'
@@ -42,6 +46,10 @@ on:
 
   workflow_dispatch:
     inputs:
+      work_dir:
+        description: 'Working directory for cargo commands'
+        default: '.'
+        type: string
       binary_tag:
         description: 'Base name for output binaries and packages'
         default: 'cadman'
@@ -83,6 +91,7 @@ jobs:
       - id: set
         env:
           BINARY_TAG: ${{ inputs.binary_tag }}
+          WORK_DIR: ${{ inputs.work_dir }}
           BUILD_LINUX_X86_64: ${{ inputs.build_linux_x86_64 }}
           BUILD_LINUX_AARCH64: ${{ inputs.build_linux_aarch64 }}
           BUILD_MACOS_X86_64: ${{ inputs.build_macos_x86_64 }}
@@ -93,6 +102,7 @@ jobs:
         run: |
           echo "## 🚧 Build Plan" >> "$GITHUB_STEP_SUMMARY"
           echo "**Binary Tag**: \`$BINARY_TAG\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Work Dir**: \`$WORK_DIR\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### 🎯 Enabled Targets" >> "$GITHUB_STEP_SUMMARY"
 
@@ -162,6 +172,7 @@ jobs:
             enabled: ${{ inputs.build_macos_aarch64 }}
 
     runs-on: ${{ matrix.os }}
+
     steps:
       - name: Skip disabled build
         if: ${{ !matrix.enabled }}
@@ -179,12 +190,13 @@ jobs:
       - if: ${{ matrix.enabled }}
         run: rustup target add ${{ matrix.target }}
 
-      - name: Install cross-linker (for aarch64 Linux)
-        if: matrix.enabled && matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Install cross-linker for aarch64 Linux
+        if: ${{ matrix.enabled && matrix.target == 'aarch64-unknown-linux-gnu' }}
         run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - if: ${{ matrix.enabled }}
         name: Build release binary
+        working-directory: ${{ inputs.work_dir }}
         env:
           CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
@@ -192,12 +204,13 @@ jobs:
 
       - if: ${{ matrix.enabled }}
         name: Rename binary
+        working-directory: ${{ inputs.work_dir }}
         env:
           BINARY_TAG: ${{ inputs.binary_tag }}
         run: |
-          BIN_NAME=$(cargo read-manifest | jq -r .targets[] | jq 'select(.kind[] == "bin") | .name' | head -n1 | tr -d '"')
+          BIN_NAME=$(cargo read-manifest | jq -r '.targets[] | select(.kind[] == "bin") | .name' | head -n1)
           echo "Detected binary: $BIN_NAME"
-          cp workspace/target/${{ matrix.target }}/release/$BIN_NAME $BINARY_TAG-${{ matrix.name }}
+          cp "target/${{ matrix.target }}/release/$BIN_NAME" "$GITHUB_WORKSPACE/$BINARY_TAG-${{ matrix.name }}"
 
       - if: ${{ matrix.enabled }}
         uses: actions/upload-artifact@v4
@@ -219,10 +232,11 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             name: linux-aarch64
             enabled: ${{ inputs.build_linux_aarch64 && inputs.package_deb }}
+
     steps:
-      - name: Skip disabled build
+      - name: Skip disabled .deb package
         if: ${{ !matrix.enabled }}
-        run: echo "Build for ${{ matrix.name }} is disabled. Skipping..."
+        run: echo ".deb package for ${{ matrix.name }} is disabled. Skipping..."
 
       - if: ${{ matrix.enabled }}
         uses: actions/checkout@v4
@@ -236,23 +250,25 @@ jobs:
       - if: ${{ matrix.enabled }}
         run: cargo install cargo-deb
 
-      - if: matrix.enabled && matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Install cross-linker for aarch64 Linux
+        if: ${{ matrix.enabled && matrix.target == 'aarch64-unknown-linux-gnu' }}
         run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - if: ${{ matrix.enabled }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.binary_tag }}-${{ matrix.name }}
-          path: workspace/target/${{ matrix.target }}/release/
+          path: ${{ github.workspace }}/${{ inputs.work_dir }}/target/${{ matrix.target }}/release/
 
       - if: ${{ matrix.enabled }}
+        name: Build .deb package
+        working-directory: ${{ inputs.work_dir }}
         env:
           BINARY_TAG: ${{ inputs.binary_tag }}
         run: |
-          cp workspace/target/${{ matrix.target }}/release/$BINARY_TAG-${{ matrix.name }} workspace/target/${{ matrix.target }}/release/$BINARY_TAG
+          cp "target/${{ matrix.target }}/release/$BINARY_TAG-${{ matrix.name }}" "target/${{ matrix.target }}/release/$BINARY_TAG"
           cargo deb --no-build --target ${{ matrix.target }}
-          mv workspace/target/${{ matrix.target }}/debian/*.deb $BINARY_TAG-${{ matrix.name }}.deb
-
+          mv target/${{ matrix.target }}/debian/*.deb "$GITHUB_WORKSPACE/$BINARY_TAG-${{ matrix.name }}.deb"
 
       - if: ${{ matrix.enabled }}
         uses: actions/upload-artifact@v4
@@ -274,10 +290,11 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             name: linux-aarch64
             enabled: ${{ inputs.build_linux_aarch64 && inputs.package_rpm }}
+
     steps:
-      - name: Skip disabled build
+      - name: Skip disabled .rpm package
         if: ${{ !matrix.enabled }}
-        run: echo "Build for ${{ matrix.name }}.rpm is disabled. Skipping..."
+        run: echo ".rpm package for ${{ matrix.name }} is disabled. Skipping..."
 
       - if: ${{ matrix.enabled }}
         uses: actions/checkout@v4
@@ -291,24 +308,26 @@ jobs:
       - if: ${{ matrix.enabled }}
         run: cargo install cargo-generate-rpm
 
-      - if: matrix.enabled && matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Install cross-linker for aarch64 Linux
+        if: ${{ matrix.enabled && matrix.target == 'aarch64-unknown-linux-gnu' }}
         run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - if: ${{ matrix.enabled }}
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.binary_tag }}-${{ matrix.name }}
-          path: workspace/target/${{ matrix.target }}/release/
+          path: ${{ github.workspace }}/${{ inputs.work_dir }}/target/${{ matrix.target }}/release/
 
       - if: ${{ matrix.enabled }}
+        name: Build .rpm package
+        working-directory: ${{ inputs.work_dir }}
         env:
           BINARY_TAG: ${{ inputs.binary_tag }}
         run: |
-          cp workspace/target/${{ matrix.target }}/release/$BINARY_TAG-${{ matrix.name }} workspace/target/${{ matrix.target }}/release/$BINARY_TAG
-          mkdir -p workspace/target/${{ matrix.target }}/rpm/
-          cargo generate-rpm --target ${{ matrix.target }} --output workspace/target/${{ matrix.target }}/rpm/
-          mv workspace/target/${{ matrix.target }}/rpm/*.rpm $BINARY_TAG-${{ matrix.name }}.rpm
-
+          cp "target/${{ matrix.target }}/release/$BINARY_TAG-${{ matrix.name }}" "target/${{ matrix.target }}/release/$BINARY_TAG"
+          mkdir -p "target/${{ matrix.target }}/rpm/"
+          cargo generate-rpm --target ${{ matrix.target }} --output "target/${{ matrix.target }}/rpm/"
+          mv target/${{ matrix.target }}/rpm/*.rpm "$GITHUB_WORKSPACE/$BINARY_TAG-${{ matrix.name }}.rpm"
 
       - if: ${{ matrix.enabled }}
         uses: actions/upload-artifact@v4
@@ -320,10 +339,11 @@ jobs:
     name: Prepare Homebrew tarballs
     runs-on: ubuntu-latest
     needs: build
+
     steps:
-      - name: Skip disabled build
+      - name: Skip disabled Homebrew package
         if: ${{ !inputs.package_homebrew }}
-        run: echo "Build for Homebrew tarballs is disabled. Skipping..."
+        run: echo "Homebrew tarballs are disabled. Skipping..."
 
       - if: ${{ inputs.package_homebrew }}
         uses: actions/checkout@v4
@@ -348,18 +368,20 @@ jobs:
 
           if [ "$BUILD_MACOS_X86_64" = "true" ]; then
             file="macos-bin/$BINARY_TAG-macos-x86_64/$BINARY_TAG-macos-x86_64"
-            if ls $file 1>/dev/null 2>&1; then
+            if [ -f "$file" ]; then
               cp "$file" "$BINARY_TAG"
               tar -czvf "dist/$BINARY_TAG-macos-x86_64.tar.gz" "$BINARY_TAG"
+              rm -f "$BINARY_TAG"
               built_any=true
             fi
           fi
 
           if [ "$BUILD_MACOS_AARCH64" = "true" ]; then
             file="macos-bin/$BINARY_TAG-macos-aarch64/$BINARY_TAG-macos-aarch64"
-            if ls $file 1>/dev/null 2>&1; then
+            if [ -f "$file" ]; then
               cp "$file" "$BINARY_TAG"
               tar -czvf "dist/$BINARY_TAG-macos-aarch64.tar.gz" "$BINARY_TAG"
+              rm -f "$BINARY_TAG"
               built_any=true
             fi
           fi
@@ -369,12 +391,11 @@ jobs:
             exit 0
           fi
 
-      - uses: actions/upload-artifact@v4
-        if: ${{ inputs.package_homebrew }} && success()
+      - if: ${{ inputs.package_homebrew && success() }}
+        uses: actions/upload-artifact@v4
         with:
           name: homebrew-tarballs
           path: dist/*.tar.gz
-
 
   aggregate:
     name: Aggregate Artifacts
@@ -384,6 +405,7 @@ jobs:
       - package-deb
       - package-rpm
       - package-homebrew
+
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
This pull request updates the `.github/workflows/build.yml` workflow to improve flexibility and maintainability, primarily by introducing a configurable working directory for cargo commands and cleaning up path handling and step naming. These changes make it easier to build and package binaries from different directories and clarify the workflow steps.

**Key changes include:**

#### Flexible Working Directory Support
- Added a new `work_dir` input parameter to the workflow, allowing users to specify the working directory for cargo commands. This input is now used throughout the build, .deb, and .rpm packaging jobs to set the working directory for relevant steps. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R10-R13) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R49-R52) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R94) [[4]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R105) [[5]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L182-R213) [[6]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L239-R271) [[7]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L294-R330)

#### Path Handling and Artifact Management
- Updated all file and artifact paths to use the new `work_dir` input and `${{ github.workspace }}` to ensure consistent and correct file locations regardless of the working directory. This removes hardcoded `workspace/` prefixes and improves portability. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L182-R213) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L239-R271) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L294-R330)

#### Step Naming and Clarity
- Improved step names for package jobs (e.g., ".deb", ".rpm", and Homebrew tarballs) to clarify when a build is being skipped due to configuration. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R235-R239) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R293-R297) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R342-R346)

#### Scripting Robustness
- Replaced `ls` checks with `[ -f "$file" ]` in Homebrew tarball preparation for more robust file existence checks and added cleanup of temporary files.

#### Minor Workflow Cleanups
- Minor formatting and ordering improvements, such as grouping steps more clearly and removing unnecessary blank lines. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R175) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L372-L378) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R408)